### PR TITLE
Refactor ListWithProperty arguments

### DIFF
--- a/job/config.go
+++ b/job/config.go
@@ -21,7 +21,7 @@ const (
 // Config configures the runner
 type Config struct {
 	ParentDataset        string            `json:"ParentDataset" yaml:"ParentDataset"`
-	DatasetType          zfs.DatasetType   `json:"DatasetTypes" yaml:"DatasetTypes"`
+	DatasetType          zfs.DatasetType   `json:"DatasetType" yaml:"DatasetType"`
 	HTTPHeaders          map[string]string `json:"HTTPHeaders" yaml:"HTTPHeaders"`
 	SnapshotNameTemplate string            `json:"SnapshotNameTemplate" yaml:"SnapshotNameTemplate"`
 

--- a/job/filesystem_prune.go
+++ b/job/filesystem_prune.go
@@ -12,7 +12,11 @@ import (
 func (r *Runner) pruneFilesystems() error {
 	deleteProp := r.config.Properties.deleteAt()
 
-	filesystems, err := zfs.ListWithProperty(r.ctx, zfs.DatasetFilesystem, r.config.ParentDataset, deleteProp)
+	filesystems, err := zfs.ListWithProperty(r.ctx, deleteProp, zfs.ListWithPropertyOptions{
+		ParentDataset:   r.config.ParentDataset,
+		DatasetType:     zfs.DatasetFilesystem,
+		PropertySources: []zfs.PropertySource{zfs.PropertySourceLocal},
+	})
 	switch {
 	case errors.Is(err, zfs.ErrDatasetNotFound):
 		return nil
@@ -37,7 +41,11 @@ func (r *Runner) pruneFilesystems() error {
 	}
 
 	deleteWithoutSnaps := r.config.Properties.deleteWithoutSnapshots()
-	filesystems, err = zfs.ListWithProperty(r.ctx, zfs.DatasetFilesystem, r.config.ParentDataset, deleteWithoutSnaps)
+	filesystems, err = zfs.ListWithProperty(r.ctx, deleteWithoutSnaps, zfs.ListWithPropertyOptions{
+		ParentDataset:   r.config.ParentDataset,
+		DatasetType:     r.config.DatasetType,
+		PropertySources: []zfs.PropertySource{zfs.PropertySourceLocal},
+	})
 	switch {
 	case errors.Is(err, zfs.ErrDatasetNotFound):
 		return nil

--- a/job/snapshots_create.go
+++ b/job/snapshots_create.go
@@ -16,7 +16,11 @@ func (r *Runner) createSnapshots() error {
 	intervalProp := r.config.Properties.snapshotIntervalMinutes()
 	deleteProp := r.config.Properties.deleteAt()
 
-	datasets, err := zfs.ListWithProperty(r.ctx, r.config.DatasetType, r.config.ParentDataset, intervalProp)
+	datasets, err := zfs.ListWithProperty(r.ctx, intervalProp, zfs.ListWithPropertyOptions{
+		ParentDataset:   r.config.ParentDataset,
+		DatasetType:     r.config.DatasetType,
+		PropertySources: []zfs.PropertySource{zfs.PropertySourceLocal},
+	})
 	switch {
 	case errors.Is(err, zfs.ErrDatasetNotFound):
 		return nil

--- a/job/snapshots_mark.go
+++ b/job/snapshots_mark.go
@@ -23,7 +23,12 @@ func (r *Runner) markPrunableSnapshots() error {
 
 func (r *Runner) markPrunableExcessSnapshots() error {
 	countProp := r.config.Properties.snapshotRetentionCount()
-	datasets, err := zfs.ListWithProperty(r.ctx, r.config.DatasetType, r.config.ParentDataset, countProp)
+
+	datasets, err := zfs.ListWithProperty(r.ctx, countProp, zfs.ListWithPropertyOptions{
+		ParentDataset:   r.config.ParentDataset,
+		DatasetType:     r.config.DatasetType,
+		PropertySources: []zfs.PropertySource{zfs.PropertySourceLocal},
+	})
 	switch {
 	case errors.Is(err, zfs.ErrDatasetNotFound):
 		return nil
@@ -142,7 +147,12 @@ func (r *Runner) markExcessDatasetSnapshots(ds *zfs.Dataset, maxCount int64) err
 
 func (r *Runner) markPrunableSnapshotsByAge() error {
 	retentionProp := r.config.Properties.snapshotRetentionMinutes()
-	datasets, err := zfs.ListWithProperty(r.ctx, r.config.DatasetType, r.config.ParentDataset, retentionProp)
+
+	datasets, err := zfs.ListWithProperty(r.ctx, retentionProp, zfs.ListWithPropertyOptions{
+		ParentDataset:   r.config.ParentDataset,
+		DatasetType:     r.config.DatasetType,
+		PropertySources: []zfs.PropertySource{zfs.PropertySourceLocal},
+	})
 	switch {
 	case errors.Is(err, zfs.ErrDatasetNotFound):
 		return nil

--- a/job/snapshots_prune.go
+++ b/job/snapshots_prune.go
@@ -11,7 +11,12 @@ import (
 func (r *Runner) pruneSnapshots() error {
 	deleteProp := r.config.Properties.deleteAt()
 
-	snapshots, err := zfs.ListWithProperty(r.ctx, zfs.DatasetSnapshot, r.config.ParentDataset, deleteProp)
+	snapshots, err := zfs.ListWithProperty(r.ctx, deleteProp, zfs.ListWithPropertyOptions{
+		ParentDataset: r.config.ParentDataset,
+		DatasetType:   zfs.DatasetSnapshot,
+		// Also include inherited here, so we delete snapshots when the parent Filesystem is marked for deletion:
+		PropertySources: []zfs.PropertySource{zfs.PropertySourceLocal, zfs.PropertySourceInherited},
+	})
 	switch {
 	case errors.Is(err, zfs.ErrDatasetNotFound):
 		return nil

--- a/job/snapshots_send.go
+++ b/job/snapshots_send.go
@@ -16,7 +16,11 @@ var ErrNoCommonSnapshots = errors.New("local and remote datasets have no common 
 func (r *Runner) sendSnapshots(routineID int) error {
 	sendToProp := r.config.Properties.snapshotSendTo()
 
-	datasets, err := zfs.ListWithProperty(r.ctx, r.config.DatasetType, r.config.ParentDataset, sendToProp)
+	datasets, err := zfs.ListWithProperty(r.ctx, sendToProp, zfs.ListWithPropertyOptions{
+		ParentDataset:   r.config.ParentDataset,
+		DatasetType:     r.config.DatasetType,
+		PropertySources: []zfs.PropertySource{zfs.PropertySourceLocal},
+	})
 	switch {
 	case errors.Is(err, zfs.ErrDatasetNotFound):
 		return nil

--- a/properties.go
+++ b/properties.go
@@ -1,5 +1,25 @@
 package zfs
 
+type PropertySource string
+
+type PropertySources []PropertySource
+
+func (ps PropertySources) StringSlice() []string {
+	strs := make([]string, len(ps))
+	for i, p := range ps {
+		strs[i] = string(p)
+	}
+	return strs
+}
+
+const (
+	PropertySourceLocal     PropertySource = "local"
+	PropertySourceInherited PropertySource = "inherited"
+	PropertySourceTemporary PropertySource = "temporary"
+	PropertySourceReceived  PropertySource = "received"
+	PropertySourceDefault   PropertySource = "default"
+)
+
 const (
 	PropertyAvailable          = "available"
 	PropertyCanMount           = "canmount"

--- a/zfs_test.go
+++ b/zfs_test.go
@@ -252,7 +252,10 @@ func TestListWithProperty(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, f1.SetProperty(context.Background(), prop, "123"))
 
-		ls, err := ListWithProperty(context.Background(), DatasetFilesystem, testZPool+"/list-test", prop)
+		ls, err := ListWithProperty(context.Background(), prop, ListWithPropertyOptions{
+			ParentDataset: testZPool + "/list-test",
+			DatasetType:   DatasetFilesystem,
+		})
 		require.NoError(t, err)
 		require.Len(t, ls, 1)
 		require.Equal(t, map[string]string{


### PR DESCRIPTION
(breaking change)

In order for delete snapshots to work when we set the delete-at property on its parent filesystem, we need to be able to set the property scope on the function. All of the arguments except property can also be optional now. Use a struct for better forwards compatibility in the future.