### PR TITLE
Handle zfs.ErrDatasetNotFound in the various job runner tasks

### DIFF
--- a/job/runner.go
+++ b/job/runner.go
@@ -2,6 +2,7 @@ package job
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -132,7 +133,11 @@ func (r *Runner) datasetHasLockProperty(dataset string) bool {
 	prop := r.config.Properties.datasetLocked()
 
 	ds, err := zfs.GetDataset(r.ctx, dataset, prop)
-	if err != nil {
+	switch {
+	case errors.Is(err, zfs.ErrDatasetNotFound):
+		r.logger.Warn("zfs.job.runner.datasetHasLockProperty: Dataset gone", "dataset", dataset, "error", err)
+		return true // Lets not proceed by locking a nonexisting dataset
+	case err != nil:
 		r.logger.Error("zfs.job.runner.datasetHasLockProperty: Error retrieving dataset", "dataset", dataset, "error", err)
 		return true // Lets assume it is locked then!
 	}

--- a/job/snapshots_mark.go
+++ b/job/snapshots_mark.go
@@ -42,7 +42,10 @@ func (r *Runner) markPrunableExcessSnapshots() error {
 		}
 
 		ds, err := zfs.GetDataset(r.ctx, dataset, countProp)
-		if err != nil {
+		switch {
+		case errors.Is(err, zfs.ErrDatasetNotFound):
+			continue // Dataset was removed meanwhile, continue with next one
+		case err != nil:
 			return fmt.Errorf("error retrieving count retention dataset %s: %w", dataset, err)
 		}
 
@@ -170,7 +173,10 @@ func (r *Runner) markPrunableSnapshotsByAge() error {
 		}
 
 		ds, err := zfs.GetDataset(r.ctx, dataset, retentionProp)
-		if err != nil {
+		switch {
+		case errors.Is(err, zfs.ErrDatasetNotFound):
+			continue // Dataset was removed meanwhile, continue with next one
+		case err != nil:
 			return fmt.Errorf("error retrieving time retention dataset %s: %w", dataset, err)
 		}
 

--- a/job/snapshots_prune.go
+++ b/job/snapshots_prune.go
@@ -66,7 +66,10 @@ func (r *Runner) pruneMarkedSnapshot(snapshot string) error {
 	deleteProp := r.config.Properties.deleteAt()
 
 	snap, err := zfs.GetDataset(r.ctx, snapshot, deleteProp)
-	if err != nil {
+	switch {
+	case errors.Is(err, zfs.ErrDatasetNotFound):
+		return nil // Dataset was removed meanwhile, return early
+	case err != nil:
 		return fmt.Errorf("error getting snapshot %s: %w", snapshot, err)
 	}
 

--- a/job/snapshots_send.go
+++ b/job/snapshots_send.go
@@ -53,8 +53,11 @@ func (r *Runner) sendDatasetSnapshotsByName(routineID int, dataset string) error
 	deleteProp := r.config.Properties.deleteAt()
 
 	ds, err := zfs.GetDataset(r.ctx, dataset, sendToProp, sendingProp, deleteProp)
-	if err != nil {
-		return fmt.Errorf("error retrieving snapshottable dataset %s: %w", dataset, err)
+	switch {
+	case errors.Is(err, zfs.ErrDatasetNotFound):
+		return nil // Dataset was removed meanwhile, continue with the next one
+	case err != nil:
+		return fmt.Errorf("error retrieving sendable dataset %s: %w", dataset, err)
 	}
 
 	server := ds.ExtraProps[sendToProp]


### PR DESCRIPTION
When it occurs, just proceed to the next dataset in line instead of erroring out.