### PR TITLE
Return ErrDatasetNotFound when trying to send a snapshot that no longer exists

### DIFF
--- a/error.go
+++ b/error.go
@@ -8,10 +8,11 @@ import (
 )
 
 const (
-	datasetNotFoundMessage = "dataset does not exist"
-	resumableErrorMessage  = "resuming stream can be generated on the sending system"
-	datasetBusyMessage     = "pool or dataset is busy"
-	datasetExistsMessage   = "exists"
+	datasetNotFoundMessage       = "dataset does not exist"
+	resumableErrorMessage        = "resuming stream can be generated on the sending system"
+	datasetBusyMessage           = "pool or dataset is busy"
+	datasetNoLongerExistsMessage = "no longer exists"
+	datasetExistsMessage         = "exists"
 )
 
 var (
@@ -57,6 +58,8 @@ func createError(cmd *exec.Cmd, stderr string, err error) error {
 			stderr = stderr[:idx]
 		}
 		return fmt.Errorf("%s: %w", stderr, ErrPoolOrDatasetBusy)
+	case strings.Contains(stderr, datasetNoLongerExistsMessage):
+		return fmt.Errorf("%s: %w", stderr, ErrDatasetNotFound)
 	case strings.Contains(stderr, datasetExistsMessage):
 		return fmt.Errorf("%s: %w", stderr, ErrDatasetExists)
 	case strings.Contains(stderr, resumableErrorMessage):


### PR DESCRIPTION
This error is for example returned when trying to send a resume stream:

```
cannot resume send: 'parentDS/datasetName@snapshotName' used in the initial send no longer exists
```