### PR TITLE
Add ErrSnapshotHasDependentClones and emit warning instead of error on prune job

### DIFF
--- a/job/snapshots_prune.go
+++ b/job/snapshots_prune.go
@@ -39,6 +39,14 @@ func (r *Runner) pruneSnapshots() error {
 				"full", snapshot,
 			)
 			return nil // Return no error
+		case errors.Is(err, zfs.ErrSnapshotHasDependentClones):
+			r.logger.Warn("zfs.job.Runner.pruneSnapshots: Snapshot in use",
+				"error", err,
+				"dataset", datasetName(snapshot, true),
+				"snapshot", snapshotName(snapshot),
+				"full", snapshot,
+			)
+			continue // Nothing to do here, next
 		case err != nil:
 			r.logger.Error("zfs.job.Runner.pruneSnapshots: Error pruning snapshot",
 				"error", err,


### PR DESCRIPTION
This error is returned when the snapshot being deleted is used in a clone.

Example:
```
cannot destroy 'parent/dataset@snapshot': snapshot has dependent clones
use '-R' to destroy the following datasets:
parent/dataset-clone@snapshot
parent/dataset-clone
```